### PR TITLE
Use system's temp directory instead of `/tmp/`

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -4,7 +4,7 @@ import User from './models/user.model';
 
 const sequelize = new Sequelize(null, null, null, {
   dialect: 'sqlite',
-  storage: '/tmp/db.sqlite',
+  storage: path.join(os.tmpdir(), 'db.sqlite'),
   logging: false
 });
 


### PR DESCRIPTION
Use system's default directory for temporary files instead of `/tmp/` for database. It closes #4.

Is it required to include modules `path` and `os`?
```javascript
var path = require('path');
var os = require('os');
```